### PR TITLE
Addressed an issue in which the `updateEmployeeRole()` function was not invoked from the command line interface

### DIFF
--- a/api/inquirer.js
+++ b/api/inquirer.js
@@ -191,7 +191,7 @@ const switchCommand = (commandObject) => {
 		case "Add an employee":
 			addEmployee();
 			break;
-		case "Update an employee role":
+		case "Update an employee's role":
 			updateEmployeeRole();
 			break;
 		case "Exit":


### PR DESCRIPTION
The text in the `commandQuestion`'s choices was slightly modified for the "Update an employee's role" choice. The change to this option no longer aligned with the switch statement's cases in `switchCommand()`; thus, `updateEmployeeRole()` was no longer being invoked.

In this pull request, I updated the case text to mirror the new prompt.